### PR TITLE
Add static file support for templates

### DIFF
--- a/core/components/switchtemplate/model/switchtemplate/switchtemplate.class.php
+++ b/core/components/switchtemplate/model/switchtemplate/switchtemplate.class.php
@@ -363,7 +363,7 @@ class SwitchTemplate
 
                     if ($template = $this->modx->getObject('modTemplate', array('templatename' => $templatename))) {
                         // get the template content
-                        $resource->_output = $template->get('content');
+                        $resource->_output = $template->process();
                     } else {
                         // fallback to normal resource
                         $message = $this->modx->lexicon('switchtemplate.err_template_nf', array('name' => $templateName));


### PR DESCRIPTION
Currently if a MODX template is set to a static file, switchTemplate does not pick up changes to that file. This is because it fetches the template content directly from the database.

This PR make use of the modTemplate->process() method instead which will pick up changes in the static template file without having to save the template in MODX GUI after every change.